### PR TITLE
[GITHUB-10] Removed minor from default version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ rsyslog:
   # in an extending role
   default_config: yes
   max_message_size: 64k
-  version: "8.23.*"
+  version: "8.*"
 
   # Built in log handlers
   builtin_configs:


### PR DESCRIPTION
Rsyslog apt repo seems to shed minor versions regularly,
pegging to a minor version will result in regular build failures
unless a local mirror is in use.