### PR TITLE
[GITHUB-24] rectify the output filenames for the docker config templates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,13 +41,13 @@ rsyslog:
       enabled: false
       template:
         src: "rsyslog.d/15-docker-text-logs-shipping.conf.j2"
-        dest: "/etc/rsyslog.d/15-docker-text-logs-shipping.conf.j2"
+        dest: "/etc/rsyslog.d/15-docker-text-logs-shipping.conf"
 
     docker_json_logs:
       enabled: false
       template:
         src: "rsyslog.d/16-docker-json-logs.shipping.conf.j2"
-        dest: "/etc/rsyslog.d/16-docker-json-logs.shipping.conf.j2"
+        dest: "/etc/rsyslog.d/16-docker-json-logs.shipping.conf"
 
     # handler for any logs formatted in json
     json_logs:


### PR DESCRIPTION
There was a bug in the initial PR for this feature.
This PR fixes that bug.