### PR TITLE
[GITHUB-26] Rectify the ordering of resource definitions

### DIFF
--- a/templates/rsyslog.d/15-docker-text-logs-shipping.conf.j2
+++ b/templates/rsyslog.d/15-docker-text-logs-shipping.conf.j2
@@ -12,21 +12,6 @@ input(type="imuxsock"
 	ruleset="remoteDockerTextLog"
 )
 
-ruleset(name="remoteDockerTextLog") {
-	# Don't log ELB healthchecks
-	:msg, contains, "ELB-HealthChecker" stop
-	:msg, contains, "healthcheck" stop
-	action(
-		type="omfwd"
-		Target="{{ rsyslog.logstash.host }}"
-		Port="{{ rsyslog.logstash.port }}"
-		Protocol="tcp"
-		RebindInterval="100"
-		template="textDockerLogTemplate"
-	)
-	stop
-}
-
 # Template for non syslog messages via docker, just sends the message wholesale with extra
 # furniture. Intended as a receiver via imuxsock from the Docker syslog log driver.
 template(name="textDockerLogTemplate"
@@ -48,4 +33,19 @@ template(name="textDockerLogTemplate"
 	constant(value="\"message\":\"")
 	property(name="msg" format="json" position.from="2")
 	constant(value="\"}\n")
+}
+
+ruleset(name="remoteDockerTextLog") {
+	# Don't log ELB healthchecks
+	:msg, contains, "ELB-HealthChecker" stop
+	:msg, contains, "healthcheck" stop
+	action(
+		type="omfwd"
+		Target="{{ rsyslog.logstash.host }}"
+		Port="{{ rsyslog.logstash.port }}"
+		Protocol="tcp"
+		RebindInterval="100"
+		template="textDockerLogTemplate"
+	)
+	stop
 }

--- a/templates/rsyslog.d/16-docker-json-logs.shipping.conf.j2
+++ b/templates/rsyslog.d/16-docker-json-logs.shipping.conf.j2
@@ -12,22 +12,6 @@ input(type="imuxsock"
 	ruleset="remoteDockerJsonLog"
 )
 
-ruleset(name="remoteDockerJsonLog") {
-	# Don't log ELB healthchecks
-	:msg, contains, "ELB-HealthChecker" stop
-	:msg, contains, "healthcheck" stop
-	action(type="mmjsonparse" cookie="")
-	action(
-		type="omfwd"
-		Target="{{ rsyslog.logstash.host }}"
-		Port="{{ rsyslog.logstash.port }}"
-		Protocol="tcp"
-		RebindInterval="100"
-		template="jsonDockerLogTemplate"
-	)
-	stop
-}
-
 # Template for shipping JSON logs from Docker
 # Just adds some furniture to the json message
 template(name="jsonDockerLogTemplate"
@@ -44,4 +28,20 @@ template(name="jsonDockerLogTemplate"
 	property(name="programname")
 	constant(value="\", ")
 	property(name="msg" position.from="2")
+}
+
+ruleset(name="remoteDockerJsonLog") {
+	# Don't log ELB healthchecks
+	:msg, contains, "ELB-HealthChecker" stop
+	:msg, contains, "healthcheck" stop
+	action(type="mmjsonparse" cookie="")
+	action(
+		type="omfwd"
+		Target="{{ rsyslog.logstash.host }}"
+		Port="{{ rsyslog.logstash.port }}"
+		Protocol="tcp"
+		RebindInterval="100"
+		template="jsonDockerLogTemplate"
+	)
+	stop
 }


### PR DESCRIPTION
The order of the resources in the docker config files was incorrect.